### PR TITLE
corrected reducer type to `(state, action) -> state`

### DIFF
--- a/SwiftyRedux/Sources/BatchedActions/BatchedActions.swift
+++ b/SwiftyRedux/Sources/BatchedActions/BatchedActions.swift
@@ -16,11 +16,11 @@ public struct BatchAction: BatchedActions {
 /// Handling bundled actions in reducer
 
 public func enableBatching<State>(_ reducer: @escaping Reducer<State>) -> Reducer<State> {
-    func batchingReducer(_ action: Action, _ state: State) -> State {
+    func batchingReducer(_ state: State, _ action: Action) -> State {
         guard let batchAction = action as? BatchedActions else {
-            return reducer(action, state)
+            return reducer(state, action)
         }
-        return batchAction.actions.reduce(state) { batchingReducer($1, $0) }
+        return batchAction.actions.reduce(state, batchingReducer)
     }
     return batchingReducer
 }

--- a/SwiftyRedux/Sources/Core/Reducer.swift
+++ b/SwiftyRedux/Sources/Core/Reducer.swift
@@ -7,12 +7,12 @@
 /// They can be nested and combined together.
 /// And it's better if they are split into smaller reducers that are focused on a small domain state.
 
-public typealias Reducer<State> = (_ action: Action, _ state: State) -> State
+public typealias Reducer<State> = (_ state: State, _ action: Action) -> State
 
 public func combineReducers<State>(_ first: @escaping Reducer<State>, _ rest: Reducer<State>...) -> Reducer<State> {
-    return { action, state in
-        rest.reduce(first(action, state)) { state, reducer in
-            reducer(action, state)
+    return { state, action in
+        rest.reduce(first(state, action)) { state, reducer in
+            reducer(state, action)
         }
     }
 }

--- a/SwiftyRedux/Sources/Core/Store.swift
+++ b/SwiftyRedux/Sources/Core/Store.swift
@@ -54,7 +54,7 @@ public final class Store<State> {
 
     private func defaultDispatch(from action: Action) {
         queue.writeAndWait {
-            self.currentState = self.reducer(action, self.currentState)
+            self.currentState = self.reducer(self.currentState, action)
             self.observer.update(self.currentState)
         }
     }

--- a/SwiftyRedux/Tests/BatchedActions/EnableBatchingTests.swift
+++ b/SwiftyRedux/Tests/BatchedActions/EnableBatchingTests.swift
@@ -11,7 +11,7 @@ private class MockReducer {
     private(set) var reducer: Reducer<State>!
 
     init() {
-        reducer = { action, state in
+        reducer = { state, action in
             self.calledWithAction.append(action)
             return state
         }
@@ -30,20 +30,21 @@ class EnableBatchingTests: XCTestCase {
     }
 
     func testNonBatchedActionsArePassedThrough() {
-        _ = batchedReducer(AnyAction.one, 0)
-        _ = batchedReducer(AnyAction.two, 0)
+        _ = batchedReducer(0, AnyAction.one)
+        _ = batchedReducer(0, AnyAction.two)
 
         XCTAssertEqual(mock.calledWithAction as! [AnyAction], [.one, .two])
     }
 
     func testEachActionInsideBatchedActionIsPassedThroughSeparately() {
-        _ = batchedReducer(BatchAction(AnyAction.one, AnyAction.two), 0)
+        _ = batchedReducer(0, BatchAction(AnyAction.one, AnyAction.two))
 
         XCTAssertEqual(mock.calledWithAction as! [AnyAction], [.one, .two])
     }
 
     func testEachActionInsideNestedBatchedActionIsPassedThroughSeparatelyInCorrectOrder() {
         _ = batchedReducer(
+            0,
             BatchAction(
                 AnyAction.one,
                 BatchAction(
@@ -54,8 +55,8 @@ class EnableBatchingTests: XCTestCase {
                     AnyAction.four
                 ),
                 AnyAction.five
-            ),
-        0)
+            )
+        )
 
         XCTAssertEqual(mock.calledWithAction as! [AnyAction], [.one, .two, .three, .four, .five])
     }
@@ -65,7 +66,7 @@ class EnableBatchingTests: XCTestCase {
             let actions: [Action]
         }
 
-        _ = batchedReducer(CustomBatchAction(actions: [AnyAction.one, AnyAction.two]), 0)
+        _ = batchedReducer(0, CustomBatchAction(actions: [AnyAction.one, AnyAction.two]))
 
         XCTAssertEqual(mock.calledWithAction as! [AnyAction], [.one, .two])
     }

--- a/SwiftyRedux/Tests/Command/Redux+CommandTests.swift
+++ b/SwiftyRedux/Tests/Command/Redux+CommandTests.swift
@@ -14,7 +14,7 @@ class ReduxCommandTests: XCTestCase {
         super.setUp()
 
         initialState = 0
-        nopReducer = { action, state in state }
+        nopReducer = { state, action in state }
         nopMiddleware = createFallThroughMiddleware { getState, dispatch in return { action in } }
     }
 
@@ -22,7 +22,7 @@ class ReduxCommandTests: XCTestCase {
     func testStore_whenSubscribingWithCommand_andIncludingCurrentState_shouldRedirectToOriginalMethod_byCallingCommandForCurrentStateAndEveryNextActionDispatched() {
         var result = [State]()
         let queue = DispatchQueue(label: "testStore_whenSubscribingWithCommand_shouldRedirectToOriginalMethod_byCallingCommandForEveryActionDispatched")
-        let store = Store<State>(state: initialState, reducer: { a, s in s + 1 }, middleware: [nopMiddleware])
+        let store = Store<State>(state: initialState, reducer: { s, a in s + 1 }, middleware: [nopMiddleware])
 
         store.subscribe(on: queue, includingCurrentState: true, Command { value in result.append(value) })
 
@@ -56,7 +56,7 @@ class ReduxCommandTests: XCTestCase {
     func testStore_whenSubscribingWithCommand_shouldRedirectToOriginalMethod_byCallingCommandForEveryActionDispatched() {
         var result = [State]()
         let queue = DispatchQueue(label: "testStore_whenSubscribingWithCommand_shouldRedirectToOriginalMethod_byCallingCommandForEveryActionDispatched")
-        let store = Store<State>(state: initialState, reducer: { a, s in s + 1 }, middleware: [nopMiddleware])
+        let store = Store<State>(state: initialState, reducer: { s, a in s + 1 }, middleware: [nopMiddleware])
 
         store.subscribe(on: queue, includingCurrentState: false, Command { value in result.append(value) })
 

--- a/SwiftyRedux/Tests/Core/MiddlewareTests.swift
+++ b/SwiftyRedux/Tests/Core/MiddlewareTests.swift
@@ -20,7 +20,7 @@ class MiddlewareTests: XCTestCase {
 
         initialState = 0
         nopAction = StringAction("action")
-        nopReducer = { action, state in state }
+        nopReducer = { state, action in state }
     }
 
     func testAppliedMiddlewareIsChainedInCorrectOrder() {
@@ -116,7 +116,7 @@ class MiddlewareTests: XCTestCase {
     }
 
     func testChangesStateAfterPropagatingToTheNextMiddleware() {
-        let reducer: Reducer<State> = { action, state in
+        let reducer: Reducer<State> = { state, action in
             state + Int((action as! StringAction).value)!
         }
         let store = Store<State>(state: initialState, reducer: reducer, middleware: [

--- a/SwiftyRedux/Tests/Core/PerformanceTests.swift
+++ b/SwiftyRedux/Tests/Core/PerformanceTests.swift
@@ -13,7 +13,7 @@ class PerformanceTests: XCTestCase {
         super.setUp()
 
         observers = (0..<3000).map { _ in { _ in } }
-        store = Store<State>(state: 0, reducer: { action, state in state })
+        store = Store<State>(state: 0, reducer: { state, action in state })
     }
 
     func testNotify() {

--- a/SwiftyRedux/Tests/Core/ReducerTests.swift
+++ b/SwiftyRedux/Tests/Core/ReducerTests.swift
@@ -9,15 +9,15 @@ private class MockReducer {
     private(set) var reducer: Reducer<State>!
 
     init() {
-        reducer = { action, state in
+        reducer = { state, action in
             self.calledWithAction.append(action)
             return state
         }
     }
 }
 
-private let multiplyByTwoReducer: Reducer<State> = { action, state in state * 2 }
-private let increaseByThreeReducer: Reducer<State> = { action, state in state + 3 }
+private let multiplyByTwoReducer: Reducer<State> = { state, action in state * 2 }
+private let increaseByThreeReducer: Reducer<State> = { state, action in state + 3 }
 
 class ReducerTests: XCTestCase {
     func testCallsReducersOnce() {
@@ -26,7 +26,7 @@ class ReducerTests: XCTestCase {
         let mock2 = MockReducer()
         let reducer = combineReducers(mock1.reducer, mock2.reducer)
 
-        _ = reducer(action, 0)
+        _ = reducer(0, action)
 
         XCTAssertEqual(mock1.calledWithAction.count, 1)
         XCTAssertEqual(mock2.calledWithAction.count, 1)
@@ -36,7 +36,7 @@ class ReducerTests: XCTestCase {
 
     func testCombinedReducerResultsCorrectly() {
         let reducer = combineReducers(multiplyByTwoReducer, increaseByThreeReducer)
-        let newState = reducer(AnyAction(), 3)
+        let newState = reducer(3, AnyAction())
 
         XCTAssertEqual(newState, 9)
     }

--- a/SwiftyRedux/Tests/Core/StoreTests.swift
+++ b/SwiftyRedux/Tests/Core/StoreTests.swift
@@ -49,7 +49,7 @@ class StoreTests: XCTestCase {
         super.setUp()
 
         initialState = 0
-        nopReducer = { action, state in state }
+        nopReducer = { state, action in state }
         nopMiddleware = createFallThroughMiddleware { getState, dispatch in return { action in } }
     }
 
@@ -148,7 +148,7 @@ class StoreTests: XCTestCase {
                 next(action)
             }
         }
-        let reducer: Reducer<State> = { action, state in
+        let reducer: Reducer<State> = { state, action in
             result.append("r-\(action)")
             return state
         }
@@ -177,7 +177,7 @@ class StoreTests: XCTestCase {
         }
 
         var result = ""
-        let reducer: Reducer<State> = { action, state in
+        let reducer: Reducer<State> = { state, action in
             let action = (action as! StringAction).value
             result += action
             return state
@@ -195,7 +195,7 @@ class StoreTests: XCTestCase {
     }
 
     func testStore_whenSubscribingNotIncludingCurrentState_shouldOnlyReceiveNextStateUpdates() {
-        let reducer: Reducer<State> = { action, state in
+        let reducer: Reducer<State> = { state, action in
             switch action {
             case let action as OpAction where action == OpAction.mul: return state * 2
             case let action as OpAction where action == OpAction.inc: return state + 3
@@ -215,7 +215,7 @@ class StoreTests: XCTestCase {
     }
 
     func testStore_whenSubscribingIncludingCurrentState_shouldImmediatelyReceiveCurrentStateAndKeepReceivingNextStateUpdates() {
-        let reducer: Reducer<State> = { action, state in
+        let reducer: Reducer<State> = { state, action in
             switch action {
             case let action as OpAction where action == OpAction.mul: return state * 2
             case let action as OpAction where action == OpAction.inc: return state + 3
@@ -283,7 +283,7 @@ class StoreTests: XCTestCase {
     }
 
     func testStore_whenUnsubscribing_stopReceivingStateUpdates() {
-        let reducer: Reducer<State> = { action, state in
+        let reducer: Reducer<State> = { state, action in
             (action as! AnyAction).rawValue
         }
         let store = Store<State>(state: initialState, reducer: reducer)

--- a/SwiftyRedux/Tests/Steroids/Store+SteroidsTests.swift
+++ b/SwiftyRedux/Tests/Steroids/Store+SteroidsTests.swift
@@ -9,7 +9,7 @@ private enum OpAction: Action, Equatable { case inc, mul }
 class StoreSteroidsTests: XCTestCase {
     func testSubscribeToStore_whenSkippingRepeats_shouldReceiveUniqueStateUpdates() {
         let actions: [AnyAction] = [.one, .two, .one, .one, .three, .three, .five, .two]
-        let reducer: Reducer<State> = { action, state in
+        let reducer: Reducer<State> = { state, action in
             (action as! AnyAction).rawValue
         }
         let store = Store<State>(state: 0, reducer: reducer)
@@ -25,7 +25,7 @@ class StoreSteroidsTests: XCTestCase {
 
     func testSubscribeToStore_whenSkippingRepeats_andIncludingCurrentState_shouldReceiveCurrentStateAndFurtherUniqueStateUpdatesWithoutFirstUpdate() {
         let actions: [AnyAction] = [.one, .two, .one, .one, .three, .three, .five, .two]
-        let reducer: Reducer<State> = { action, state in
+        let reducer: Reducer<State> = { state, action in
             (action as! AnyAction).rawValue
         }
         let store = Store<State>(state: 0, reducer: reducer)
@@ -41,7 +41,7 @@ class StoreSteroidsTests: XCTestCase {
 
     func testSubscribeToStore_whenSkippingRepeats_andIncludingCurrentState_andFirstUpdateEqualsToCurrentState_shouldReceiveCurrentStateAndFurtherUniqueStateUpdatesWithoutFirstUpdate() {
         let actions: [AnyAction] = [.one, .two, .one, .one, .three, .three, .five, .two]
-        let reducer: Reducer<State> = { action, state in
+        let reducer: Reducer<State> = { state, action in
             (action as! AnyAction).rawValue
         }
         let store = Store<State>(state: 1, reducer: reducer)
@@ -57,7 +57,7 @@ class StoreSteroidsTests: XCTestCase {
 
     func testSubscribeToStore_whenNotSkippingRepeats_shouldReceiveDuplicatedStateUpdates() {
         let actions: [AnyAction] = [.one, .two, .one, .one, .three, .three, .five, .two]
-        let reducer: Reducer<State> = { action, state in
+        let reducer: Reducer<State> = { state, action in
             (action as! AnyAction).rawValue
         }
         let store = Store<State>(state: 0, reducer: reducer)
@@ -72,7 +72,7 @@ class StoreSteroidsTests: XCTestCase {
     }
 
     func testStore_whenUnsubscribing_shouldStopReceivingStateUpdates() {
-        let reducer: Reducer<State> = { action, state in
+        let reducer: Reducer<State> = { state, action in
             (action as! AnyAction).rawValue
         }
         let store = Store<State>(state: 0, reducer: reducer)
@@ -93,7 +93,7 @@ class StoreSteroidsTests: XCTestCase {
     }
 
     func testStore_whenObserving_andSubscribingToObserver_shouldStartReceivingStateUpdates() {
-        let reducer: Reducer<State> = { action, state in
+        let reducer: Reducer<State> = { state, action in
             switch action {
             case let action as OpAction where action == .mul: return state * 2
             case let action as OpAction where action == .inc: return state + 3


### PR DESCRIPTION
reducer had `(action, state) -> state` type which is not natural for reducing,    
thus changed it to `(state, action) -> state`